### PR TITLE
fix handling of percent symbols

### DIFF
--- a/locco.lua
+++ b/locco.lua
@@ -118,8 +118,8 @@ function generate_html(source, path, filename, sections, jump_to)
   f:write(h)
   for i=1, #sections do
     local t = template.table_entry:gsub('%%index%%', i..'')
-    t = t:gsub('%%docs_html%%', sections[i]['docs_html'])
-    t = t:gsub('%%code_html%%', sections[i]['code_html'])
+    t = t:gsub('%%docs_html%%', sections[i]['docs_html']:gsub('%%', '%%%%'))
+    t = t:gsub('%%code_html%%', sections[i]['code_html']:gsub('%%', '%%%%'))
     f:write(t)
   end
   f:write(template.footer)


### PR DESCRIPTION
Percent symbols seem to get truncated -- a simple test case is:

```
print (100 % 3)
```

Basically, when the template is expanded, gsub is used -- and gsub expects percents in the replacement text to be wildcard references.  

Added a hack which fixes it for me, there may be much better ways of doing it!
