### PR TITLE
Update URLs in README

### DIFF
--- a/README
+++ b/README
@@ -9,18 +9,18 @@ Locco is a Lua port of Docco: the original quick-and-dirty, hundred-line-
 long, literate-programming-style documentation generator. For more information,
 see the generated docs:
 
-http://rgieseke.github.com/locco/
+http://rgieseke.github.io/locco/
 
 Other languages:
 
-CoffeeScript - http://jashkenas.github.com/docco/
+CoffeeScript - http://jashkenas.github.io/docco/
 
-Ruby - http://rtomayko.github.com/rocco/
+Ruby - http://rtomayko.github.io/rocco/
 
-Sh - http://rtomayko.github.com/shocco/
+Sh - http://rtomayko.github.io/shocco/
 
-Python - http://fitzgen.github.com/pycco/
+Python - http://fitzgen.github.io/pycco/
 
-Clojure - http://fogus.github.com/marginalia/
+Clojure - http://gdeer81.github.io/marginalia/
 
-C# - http://dontangg.github.com/nocco/
+C# - http://dontangg.github.io/nocco/


### PR DESCRIPTION
Github changed to .io for pages and marginalia moved to a new maintainer.

Also, the about section of the repo also needs a URL update. 🙂 